### PR TITLE
Update the countdown every time the crab health updates. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.33'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/src/main/java/com/afkcrabhelper/AfkCrabHelperPlugin.java
+++ b/src/main/java/com/afkcrabhelper/AfkCrabHelperPlugin.java
@@ -43,6 +43,7 @@ public class AfkCrabHelperPlugin extends Plugin
     
     // Crab tracking variables
     private NPC currentCrab = null;
+    private int lastSeenHealthRatio = 0;
     private long timerStartTime = 0;
     private double initialTimeMinutes = 0.0;
 
@@ -89,17 +90,21 @@ public class AfkCrabHelperPlugin extends Plugin
                 currentlyInteractingWithCrab = true;
                 lastCrabInteraction = System.currentTimeMillis();
                 targetCrab = npc;
-                
+
+                int npcHealthRatio = npc.getHealthRatio();
+
                 // If this is a new crab or we weren't tracking before, update tracking
-                if (currentCrab != npc)
+                if (currentCrab != npc || lastSeenHealthRatio != npcHealthRatio)
                 {
                     currentCrab = npc;
+                    lastSeenHealthRatio = npcHealthRatio;
                     // Start countdown timer
                     timerStartTime = System.currentTimeMillis();
                     // Calculate initial time based on health%
-                    int healthRatio = Math.max(0, npc.getHealthRatio());
+                    int healthRatio = Math.max(0, npcHealthRatio);
                     int healthScale = Math.max(1, npc.getHealthScale());
-                    double healthPercent = (double) healthRatio / healthScale * 100.0;
+                    // After some testing, subtracting 0.5 give more accurate timing
+                    double healthPercent = (healthRatio - 0.5) / healthScale * 100.0;
                     initialTimeMinutes = healthPercent / 10.0;
                 }
             }

--- a/src/test/java/com/andmcadams/wikisync/AfkCrabHelperPluginTest.java
+++ b/src/test/java/com/andmcadams/wikisync/AfkCrabHelperPluginTest.java
@@ -1,0 +1,14 @@
+package com.andmcadams.wikisync;
+
+import com.afkcrabhelper.AfkCrabHelperPlugin;
+import net.runelite.client.RuneLite;
+import net.runelite.client.externalplugins.ExternalPluginManager;
+
+public class AfkCrabHelperPluginTest
+{
+	public static void main(String[] args) throws Exception
+	{
+		ExternalPluginManager.loadBuiltin(AfkCrabHelperPlugin.class);
+		RuneLite.main(args);
+	}
+}


### PR DESCRIPTION
This handles both issues described in #1.

Also, adjust the remaining time calculation to be more accurate and add a test class to test the plugin locally.

Here's a recording of the timer as the gemstone crab dies:

https://github.com/user-attachments/assets/b87773c4-d73c-4d3e-8e1d-0160f9fa261d